### PR TITLE
boot: bootutil: loader.c: Add check if upgrade before pushing state change

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -2244,7 +2244,9 @@ context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp)
 #endif
 
     /* Trigger status change callback with upgrading status */
-    mcuboot_status_change(MCUBOOT_STATUS_UPGRADING);
+    if (has_upgrade) {
+        mcuboot_status_change(MCUBOOT_STATUS_UPGRADING);
+    }
 
     /* Iterate over all the images. At this point there are no aborted swaps
      * and the swap types are determined for each image. By the end of the loop


### PR DESCRIPTION
Before pushing MCUBOOT_STATUS_UPGRADING, check if has_upgrade is true to ensure this is not pushed at every boot and only when needed.